### PR TITLE
IBX-10706: Fixed backport of Lock Normalizer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,6 +43,12 @@ parameters:
 			path: src/bundle/Lock/Store/DoctrineDbalStore.php
 
 		-
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: offsetAccess.invalidOffset
+			count: 1
+			path: src/bundle/Lock/Store/DoctrineDbalStore.php
+
+		-
 			message: '#^Parameter \#1 \$data \(array\{key\: mixed, ttl\?\: float\|null, only_deduplicate_in_queue\?\: bool\|null\}\) of method Ibexa\\Bundle\\Messenger\\Serializer\\Normalizer\\DeduplicateStampNormalizer\:\:denormalize\(\) should be contravariant with parameter \$data \(mixed\) of method Symfony\\Component\\Serializer\\Normalizer\\DenormalizerInterface\:\:denormalize\(\)$#'
 			identifier: method.childParameterType
 			count: 1
@@ -51,12 +57,6 @@ parameters:
 		-
 			message: '#^Cannot access offset string on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
-
-		-
-			message: '#^Parameter \#1 \$field of closure expects string, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
 

--- a/src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
@@ -27,17 +27,13 @@ final class LockKeyNormalizer implements NormalizerInterface, DenormalizerInterf
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<mixed>
      */
     public function normalize($data, ?string $format = null, array $context = []): array
     {
         assert($data instanceof Key);
 
-        return Closure::bind(fn () => array_intersect_key(
-            get_object_vars($this),
-            /** @phpstan-ignore-next-line argument.type */
-            array_flip($this->__sleep())
-        ), $data, Key::class)();
+        return $data->__serialize();
     }
 
     public function supportsNormalization($data, ?string $format = null, array $context = []): bool
@@ -56,7 +52,7 @@ final class LockKeyNormalizer implements NormalizerInterface, DenormalizerInterf
             $key,
             Key::class,
         );
-        foreach ($key->__sleep() as $serializedField) {
+        foreach (['resource', 'expiringTime', 'state'] as $serializedField) {
             $setter($serializedField);
         }
 

--- a/tests/bundle/Serializer/Normalizer/LockKeyNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/LockKeyNormalizerTest.php
@@ -88,9 +88,9 @@ final class LockKeyNormalizerTest extends TestCase
         yield [
             $key,
             [
+                'resource' => 'bar',
                 'expiringTime' => (float)($currentTime + 300),
                 'state' => [],
-                'resource' => 'bar',
             ],
         ];
 
@@ -100,11 +100,11 @@ final class LockKeyNormalizerTest extends TestCase
         yield [
             $key,
             [
+                'resource' => 'foo',
                 'expiringTime' => null,
                 'state' => [
                     'foo' => 'bar',
                 ],
-                'resource' => 'foo',
             ],
         ];
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-10706 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR fixes the issue that started occuring after `symfony/lock` update.

This re-backports `LockNormalizer`, which will be properly introduced into Symfony in 7.4.

See:
 * https://github.com/symfony/symfony/issues/60659
 * https://github.com/symfony/symfony/pull/60023

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
