### PR TITLE
IBX-11276: Adjusted `iterator_to_array` usage for SendersLocator

### DIFF
--- a/src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/LockKeyNormalizer.php
@@ -32,7 +32,7 @@ final class LockKeyNormalizer implements NormalizerInterface, DenormalizerInterf
     {
         assert($data instanceof Key);
 
-        return Closure::bind(fn () => array_intersect_key(
+        return Closure::bind(fn (): array => array_intersect_key(
             get_object_vars($this),
             /** @phpstan-ignore-next-line argument.type */
             array_flip($this->__sleep())
@@ -51,7 +51,9 @@ final class LockKeyNormalizer implements NormalizerInterface, DenormalizerInterf
     {
         $key = (new ReflectionClass(Key::class))->newInstanceWithoutConstructor();
         $setter = Closure::bind(
-            fn (string $field) => $this->$field = $data[$field],
+            function (string $field) use ($data): void {
+                $this->$field = $data[$field];
+            },
             $key,
             Key::class,
         );

--- a/src/bundle/Transport/Sender/SendersLocator.php
+++ b/src/bundle/Transport/Sender/SendersLocator.php
@@ -38,7 +38,7 @@ final class SendersLocator implements SendersLocatorInterface
             yield from $this->inner->getSenders($envelope);
         }
 
-        $classes = iterator_to_array($this->messageProvider->getHandledClasses());
+        $classes = iterator_to_array($this->messageProvider->getHandledClasses(), false);
 
         foreach ($this->listTypes($envelope) as $type) {
             if (in_array($type, $classes, true)) {

--- a/tests/bundle/Middleware/SudoMiddlewareTest.php
+++ b/tests/bundle/Middleware/SudoMiddlewareTest.php
@@ -56,7 +56,12 @@ final class SudoMiddlewareTest extends TestCase
         $this->repository
             ->expects(self::once())
             ->method('sudo')
-            ->willReturnCallback(static fn (callable $callback) => $callback());
+            ->willReturnCallback(static function (callable $callback): Envelope {
+                $envelope = $callback();
+                self::assertInstanceOf(Envelope::class, $envelope);
+
+                return $envelope;
+            });
 
         $processedEnvelope = $this->middleware->handle($envelope, $this->stack);
 

--- a/tests/bundle/Transport/Sender/SendersLocatorTest.php
+++ b/tests/bundle/Transport/Sender/SendersLocatorTest.php
@@ -108,6 +108,29 @@ final class SendersLocatorTest extends TestCase
         $this->assertMessageIsHandled($envelope);
     }
 
+    public function testGetSendersWithMultipleGenerators(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $generator = function (): \Generator {
+            yield from ['stdClass'];
+            yield from ['AnotherClass'];
+        };
+
+        $this->messageProviderMock
+            ->expects(self::once())
+            ->method('getHandledClasses')
+            ->willReturn($generator());
+
+        $locator = new SendersLocator($this->senderMock, $this->messageProviderMock, null);
+        $senders = $locator->getSenders($envelope);
+
+        $expectedSenders = [
+            'ibexa.messenger.transport' => $this->senderMock,
+        ];
+        self::assertInstanceOf(Traversable::class, $senders);
+        self::assertSame($expectedSenders, iterator_to_array($senders));
+    }
+
     private function assertMessageIsHandled(Envelope $envelope): void
     {
         $this->messageProviderMock

--- a/tests/bundle/Transport/Sender/SendersLocatorTest.php
+++ b/tests/bundle/Transport/Sender/SendersLocatorTest.php
@@ -111,7 +111,7 @@ final class SendersLocatorTest extends TestCase
     public function testGetSendersWithMultipleGenerators(): void
     {
         $envelope = new Envelope(new \stdClass());
-        $generator = function (): \Generator {
+        $generator = static function (): \Generator {
             yield from ['stdClass'];
             yield from ['AnotherClass'];
         };


### PR DESCRIPTION
| :ticket: Issue | IBX-11276 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Under certain circumstances Ibexa Messenger will fail to send a message to queue for background processing.

This is due to the fact that `Ibexa\Bundle\Messenger\Transport\MessageProviderRegistry::getHandledClasses()` return from internal `Generator`s, which share keys (in `yield from`).

This causes specific classes to be excluded from queueing.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
