### PR TITLE
IBX-11682: Fixed messages siteaccess context

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -18,17 +18,12 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup PHP Action
-              uses: shivammathur/setup-php@v2
+            - uses: ibexa/gh-workflows/actions/composer-install@main
               with:
-                  php-version: ${{ matrix.php }}
-                  coverage: none
-                  extensions: 'pdo_sqlite, gd'
-                  tools: cs2pr
-
-            - uses: ramsey/composer-install@v3
-              with:
-                  dependency-versions: "highest"
+                  gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                  satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+                  satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
@@ -49,18 +44,12 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup PHP Action
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  coverage: none
-                  extensions: pdo_sqlite, gd
-                  tools: cs2pr
-
-            - uses: ramsey/composer-install@v3
-              with:
-                  dependency-versions: "highest"
-                  composer-options: "${{ matrix.composer_options }}"
+            -   uses: ibexa/gh-workflows/actions/composer-install@main
+                with:
+                    gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                    gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                    satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+                    satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -101,17 +90,13 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   name: Setup PHP Action
-                uses: shivammathur/setup-php@v2
+            -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
-                    php-version: ${{ matrix.php }}
-                    coverage: none
-                    extensions: pdo_pgsql, gd
-                    tools: cs2pr
-
-            -   uses: ramsey/composer-install@v3
-                with:
-                    dependency-versions: "highest"
+                    gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                    gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                    satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+                    satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    php-extensions: pdo_pgsql, gd
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -163,17 +148,13 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   name: Setup PHP Action
-                uses: shivammathur/setup-php@v2
+            -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
-                    php-version: ${{ matrix.php }}
-                    coverage: none
-                    extensions: pdo_pgsql, gd
-                    tools: cs2pr
-
-            -   uses: ramsey/composer-install@v3
-                with:
-                    dependency-versions: "highest"
+                    gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                    gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                    satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+                    satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    php-extensions: pdo_mysql, gd
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -221,17 +202,13 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   name: Setup PHP Action
-                uses: shivammathur/setup-php@v2
+            -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
-                    php-version: ${{ matrix.php }}
-                    coverage: none
-                    extensions: pdo_mysql, gd
-                    tools: cs2pr
-
-            -   uses: ramsey/composer-install@v3
-                with:
-                    dependency-versions: "highest"
+                    gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                    gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                    satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+                    satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    php-extensions: pdo_mysql, gd
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/src/bundle/DependencyInjection/IbexaMessengerExtension.php
+++ b/src/bundle/DependencyInjection/IbexaMessengerExtension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\Messenger\DependencyInjection;
 
 use Ibexa\Bundle\Messenger\Middleware\DeduplicateMiddleware;
+use Ibexa\Bundle\Messenger\Middleware\SiteAccessMiddleware;
 use Ibexa\Bundle\Messenger\Middleware\SudoMiddleware;
 use Ibexa\Contracts\Messenger\Transport\MessageProviderInterface;
 use LogicException;
@@ -118,6 +119,7 @@ final class IbexaMessengerExtension extends ConfigurableExtension implements Pre
 
         $middleware = [
             ['id' => SudoMiddleware::class],
+            ['id' => SiteAccessMiddleware::class],
         ];
 
         if ($mergedConfig['deduplication_lock_storage']['enabled'] === true) {

--- a/src/bundle/EventSubscriber/SendMessageSiteAccessSubscriber.php
+++ b/src/bundle/EventSubscriber/SendMessageSiteAccessSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ibexa\Bundle\Messenger\EventSubscriber;
+
+use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+
+final class SendMessageSiteAccessSubscriber implements EventSubscriberInterface
+{
+    private SiteAccessServiceInterface $siteAccessService;
+
+    public function __construct(
+        SiteAccessServiceInterface $siteAccessService
+    ) {
+        $this->siteAccessService = $siteAccessService;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SendMessageToTransportsEvent::class => 'onSendMessageToTransport',
+        ];
+    }
+
+    public function onSendMessageToTransport(SendMessageToTransportsEvent $event): void
+    {
+        $siteAccess = $this->siteAccessService->getCurrent();
+        if ($siteAccess === null) {
+            return;
+        }
+
+        $envelope = $event->getEnvelope();
+        $envelope = $envelope->with(new SiteAccessStamp($siteAccess->name));
+        $event->setEnvelope($envelope);
+    }
+}

--- a/src/bundle/EventSubscriber/SendMessageSiteAccessSubscriber.php
+++ b/src/bundle/EventSubscriber/SendMessageSiteAccessSubscriber.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Bundle\Messenger\EventSubscriber;
 
 use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;

--- a/src/bundle/Middleware/SiteAccessMiddleware.php
+++ b/src/bundle/Middleware/SiteAccessMiddleware.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Bundle\Messenger\Middleware;
 
 use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;

--- a/src/bundle/Middleware/SiteAccessMiddleware.php
+++ b/src/bundle/Middleware/SiteAccessMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ibexa\Bundle\Messenger\Middleware;
+
+use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class SiteAccessMiddleware implements MiddlewareInterface
+{
+    private SiteAccessServiceInterface $siteAccessService;
+
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(
+        SiteAccessServiceInterface $siteAccessService,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->siteAccessService = $siteAccessService;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $stamp = $envelope->last(SiteAccessStamp::class);
+        if ($stamp !== null) {
+            $siteAccess = $this->siteAccessService->get($stamp->siteAccess);
+            $this->eventDispatcher->dispatch(new ScopeChangeEvent($siteAccess), MVCEvents::CONFIG_SCOPE_CHANGE);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/bundle/Resources/config/services/buses.yaml
+++ b/src/bundle/Resources/config/services/buses.yaml
@@ -23,6 +23,8 @@ services:
                 alias: ibexa.messenger.transport
                 is_failure_transport: false
 
+    Ibexa\Bundle\Messenger\Middleware\SiteAccessMiddleware: ~
+
     Ibexa\Bundle\Messenger\Middleware\SudoMiddleware: ~
 
     Ibexa\Bundle\Messenger\Middleware\DeduplicateMiddleware:

--- a/src/bundle/Resources/config/services/event_subscribers.yaml
+++ b/src/bundle/Resources/config/services/event_subscribers.yaml
@@ -5,3 +5,5 @@ services:
         public: false
 
     Ibexa\Bundle\Messenger\EventSubscriber\RemoveSudoStampOnSendMessageSubscriber: ~
+
+    Ibexa\Bundle\Messenger\EventSubscriber\SendMessageSiteAccessSubscriber: ~

--- a/src/bundle/Stamp/SiteAccessStamp.php
+++ b/src/bundle/Stamp/SiteAccessStamp.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Bundle\Messenger\Stamp;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;

--- a/src/bundle/Stamp/SiteAccessStamp.php
+++ b/src/bundle/Stamp/SiteAccessStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ibexa\Bundle\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * @readonly
+ */
+final class SiteAccessStamp implements StampInterface
+{
+    public string $siteAccess;
+
+    public function __construct(
+        string $siteAccess
+    ) {
+        $this->siteAccess = $siteAccess;
+    }
+
+    public function getSiteAccess(): string
+    {
+        return $this->siteAccess;
+    }
+}

--- a/tests/bundle/EventSubscriber/SendMessageSiteAccessSubscriberTest.php
+++ b/tests/bundle/EventSubscriber/SendMessageSiteAccessSubscriberTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Messenger\EventSubscriber;
+
+use Ibexa\Bundle\Messenger\EventSubscriber\SendMessageSiteAccessSubscriber;
+use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+
+final class SendMessageSiteAccessSubscriberTest extends TestCase
+{
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private SiteAccessServiceInterface $siteAccessService;
+
+    private SendMessageSiteAccessSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $this->subscriber = new SendMessageSiteAccessSubscriber($this->siteAccessService);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        $subscribedEvents = SendMessageSiteAccessSubscriber::getSubscribedEvents();
+
+        self::assertArrayHasKey(SendMessageToTransportsEvent::class, $subscribedEvents);
+        self::assertSame('onSendMessageToTransport', $subscribedEvents[SendMessageToTransportsEvent::class]);
+    }
+
+    public function testOnSendMessageToTransportAddsSiteAccessStamp(): void
+    {
+        $siteAccess = new SiteAccess('my_site');
+        $envelope = new Envelope(new \stdClass());
+        $event = new SendMessageToTransportsEvent($envelope, []);
+
+        $this->siteAccessService
+            ->expects(self::once())
+            ->method('getCurrent')
+            ->willReturn($siteAccess);
+
+        $this->subscriber->onSendMessageToTransport($event);
+
+        $updatedEnvelope = $event->getEnvelope();
+        $stamp = $updatedEnvelope->last(SiteAccessStamp::class);
+
+        self::assertNotNull($stamp);
+        self::assertSame('my_site', $stamp->siteAccess);
+    }
+
+    public function testOnSendMessageToTransportDoesNothingWhenNoSiteAccess(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $event = new SendMessageToTransportsEvent($envelope, []);
+
+        $this->siteAccessService
+            ->expects(self::once())
+            ->method('getCurrent')
+            ->willReturn(null);
+
+        $this->subscriber->onSendMessageToTransport($event);
+
+        $updatedEnvelope = $event->getEnvelope();
+
+        self::assertNull($updatedEnvelope->last(SiteAccessStamp::class));
+        self::assertSame($envelope, $updatedEnvelope);
+    }
+}

--- a/tests/bundle/EventSubscriber/SendMessageSiteAccessSubscriberTest.php
+++ b/tests/bundle/EventSubscriber/SendMessageSiteAccessSubscriberTest.php
@@ -41,7 +41,7 @@ final class SendMessageSiteAccessSubscriberTest extends TestCase
     {
         $siteAccess = new SiteAccess('my_site');
         $envelope = new Envelope(new \stdClass());
-        $event = new SendMessageToTransportsEvent($envelope, []);
+        $event = new SendMessageToTransportsEvent($envelope);
 
         $this->siteAccessService
             ->expects(self::once())
@@ -60,7 +60,7 @@ final class SendMessageSiteAccessSubscriberTest extends TestCase
     public function testOnSendMessageToTransportDoesNothingWhenNoSiteAccess(): void
     {
         $envelope = new Envelope(new \stdClass());
-        $event = new SendMessageToTransportsEvent($envelope, []);
+        $event = new SendMessageToTransportsEvent($envelope);
 
         $this->siteAccessService
             ->expects(self::once())

--- a/tests/bundle/Middleware/SiteAccessMiddlewareTest.php
+++ b/tests/bundle/Middleware/SiteAccessMiddlewareTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Messenger\Middleware;
+
+use Ibexa\Bundle\Messenger\Middleware\SiteAccessMiddleware;
+use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class SiteAccessMiddlewareTest extends TestCase
+{
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private SiteAccessServiceInterface $siteAccessService;
+
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private EventDispatcherInterface $eventDispatcher;
+
+    /** @var \Symfony\Component\Messenger\Middleware\StackInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private StackInterface $stack;
+
+    private SiteAccessMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->stack = $this->createMock(StackInterface::class);
+        $this->middleware = new SiteAccessMiddleware(
+            $this->siteAccessService,
+            $this->eventDispatcher,
+        );
+    }
+
+    public function testHandleDispatchesScopeChangeWhenSiteAccessStampExists(): void
+    {
+        $stamp = new SiteAccessStamp('my_site');
+        $envelope = new Envelope(new \stdClass(), [$stamp]);
+        $siteAccess = new SiteAccess('my_site');
+
+        $this->siteAccessService
+            ->expects(self::once())
+            ->method('get')
+            ->with('my_site')
+            ->willReturn($siteAccess);
+
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                self::callback(static function (ScopeChangeEvent $event) use ($siteAccess): bool {
+                    self::assertSame($siteAccess, $event->getSiteAccess());
+
+                    return true;
+                }),
+                MVCEvents::CONFIG_SCOPE_CHANGE,
+            );
+
+        $nextMiddleware = $this->createMock(MiddlewareInterface::class);
+        $nextMiddleware
+            ->expects(self::once())
+            ->method('handle')
+            ->willReturnArgument(0);
+
+        $this->stack
+            ->expects(self::once())
+            ->method('next')
+            ->willReturn($nextMiddleware);
+
+        $this->middleware->handle($envelope, $this->stack);
+    }
+
+    public function testHandleDoesNotDispatchScopeChangeWhenNoSiteAccessStamp(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+
+        $this->siteAccessService
+            ->expects(self::never())
+            ->method('get');
+
+        $this->eventDispatcher
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $nextMiddleware = $this->createMock(MiddlewareInterface::class);
+        $nextMiddleware
+            ->expects(self::once())
+            ->method('handle')
+            ->willReturnArgument(0);
+
+        $this->stack
+            ->expects(self::once())
+            ->method('next')
+            ->willReturn($nextMiddleware);
+
+        $result = $this->middleware->handle($envelope, $this->stack);
+
+        self::assertSame($envelope->getMessage(), $result->getMessage());
+    }
+}

--- a/tests/integration/AbstractTestKernel.php
+++ b/tests/integration/AbstractTestKernel.php
@@ -12,6 +12,7 @@ use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
 use Ibexa\Bundle\CorePersistence\IbexaCorePersistenceBundle;
 use Ibexa\Bundle\Messenger\IbexaMessengerBundle;
 use Ibexa\Contracts\Test\Core\IbexaTestKernel;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessageHandler;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -52,6 +53,7 @@ abstract class AbstractTestKernel extends IbexaTestKernel
         yield from parent::getExposedServicesByClass();
 
         yield FooMessageHandler::class;
+        yield SiteAccessServiceInterface::class;
     }
 
     protected static function getExposedServicesById(): iterable

--- a/tests/integration/MessageBusTest.php
+++ b/tests/integration/MessageBusTest.php
@@ -9,7 +9,12 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Integration\Messenger;
 
 use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+use Ibexa\Bundle\Messenger\Stamp\SiteAccessStamp;
 use Ibexa\Contracts\Test\Core\IbexaKernelTestCase;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessage;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessageHandler;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -19,6 +24,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class MessageBusTest extends IbexaKernelTestCase
 {
@@ -28,12 +34,22 @@ final class MessageBusTest extends IbexaKernelTestCase
 
     private FooMessageHandler $fooHandler;
 
+    private SiteAccessServiceInterface $siteAccessService;
+
+    private EventDispatcherInterface $eventDispatcher;
+
     protected function setUp(): void
     {
         $core = self::getIbexaTestCore();
         $this->bus = $core->getServiceByClassName(MessageBusInterface::class, 'ibexa.messenger.bus');
         $this->receiver = $core->getServiceByClassName(ReceiverInterface::class, 'ibexa.messenger.transport');
         $this->fooHandler = $core->getServiceByClassName(FooMessageHandler::class);
+        $this->siteAccessService = $core->getServiceByClassName(SiteAccessServiceInterface::class);
+        $this->eventDispatcher = self::getContainer()->get('event_dispatcher');
+
+        // Clear any SiteAccess set by the kernel to prevent the subscriber from stamping
+        // envelopes with a SiteAccess name that may not exist in the provider.
+        $this->siteAccessService->setSiteAccess(null);
     }
 
     public function testBus(): void
@@ -100,6 +116,134 @@ final class MessageBusTest extends IbexaKernelTestCase
 
         $application->run($input, new NullOutput());
         self::assertCount(1, $this->fooHandler->getHandledMessages());
+    }
+
+    /**
+     * Tests that dispatching a message while a SiteAccess is active automatically
+     * adds a SiteAccessStamp to the envelope in the transport.
+     */
+    public function testDispatchingMessageAddsSiteAccessStamp(): void
+    {
+        $siteAccess = new SiteAccess('__default_site_access__');
+        $this->siteAccessService->setSiteAccess($siteAccess);
+
+        $this->bus->dispatch(new FooMessage());
+
+        $messages = $this->getMessagesFromReceiver();
+        self::assertCount(1, $messages);
+
+        $envelope = $messages[0];
+        $stamp = $envelope->last(SiteAccessStamp::class);
+
+        self::assertNotNull($stamp);
+        self::assertSame('__default_site_access__', $stamp->siteAccess);
+    }
+
+    /**
+     * Tests that dispatching a message when no SiteAccess is set does not
+     * add a SiteAccessStamp to the envelope.
+     */
+    public function testDispatchingMessageWithoutSiteAccessDoesNotAddStamp(): void
+    {
+        $this->siteAccessService->setSiteAccess(null);
+
+        $this->bus->dispatch(new FooMessage());
+
+        $messages = $this->getMessagesFromReceiver();
+        self::assertCount(1, $messages);
+
+        $envelope = $messages[0];
+        self::assertNull($envelope->last(SiteAccessStamp::class));
+    }
+
+    /**
+     * Tests that consuming a message with a SiteAccessStamp triggers a
+     * CONFIG_SCOPE_CHANGE event with the correct SiteAccess.
+     */
+    public function testConsumingMessageWithSiteAccessStampTriggersScopeChange(): void
+    {
+        $capturedEvents = [];
+        $this->eventDispatcher->addListener(
+            MVCEvents::CONFIG_SCOPE_CHANGE,
+            static function (ScopeChangeEvent $event) use (&$capturedEvents): void {
+                $capturedEvents[] = $event;
+            },
+        );
+
+        $envelope = new Envelope(new FooMessage(), [
+            new ReceivedStamp('test'),
+            new SiteAccessStamp('__default_site_access__'),
+        ]);
+
+        $this->bus->dispatch($envelope);
+
+        self::assertCount(1, $capturedEvents);
+        self::assertSame('__default_site_access__', $capturedEvents[0]->getSiteAccess()->name);
+    }
+
+    /**
+     * Tests that consuming a message without a SiteAccessStamp does not
+     * trigger a CONFIG_SCOPE_CHANGE event.
+     */
+    public function testConsumingMessageWithoutSiteAccessStampDoesNotTriggerScopeChange(): void
+    {
+        $scopeChangeTriggered = false;
+        $this->eventDispatcher->addListener(
+            MVCEvents::CONFIG_SCOPE_CHANGE,
+            static function () use (&$scopeChangeTriggered): void {
+                $scopeChangeTriggered = true;
+            },
+        );
+
+        $envelope = new Envelope(new FooMessage(), [
+            new ReceivedStamp('test'),
+        ]);
+
+        $this->bus->dispatch($envelope);
+
+        self::assertFalse($scopeChangeTriggered);
+    }
+
+    /**
+     * Tests the full round-trip: setting a SiteAccess on dispatch, retrieving
+     * the stamped message from the transport, and re-dispatching it as received
+     * to trigger the scope change.
+     */
+    public function testFullSiteAccessRoundTrip(): void
+    {
+        // 1. Set current SiteAccess and dispatch
+        $siteAccess = new SiteAccess('__default_site_access__');
+        $this->siteAccessService->setSiteAccess($siteAccess);
+
+        $this->bus->dispatch(new FooMessage());
+
+        // 2. Retrieve from transport and verify stamp
+        $messages = $this->getMessagesFromReceiver();
+        self::assertCount(1, $messages);
+
+        $envelope = $messages[0];
+        $stamp = $envelope->last(SiteAccessStamp::class);
+        self::assertNotNull($stamp);
+        self::assertSame('__default_site_access__', $stamp->siteAccess);
+
+        // 3. Clear current SiteAccess to simulate worker context
+        $this->siteAccessService->setSiteAccess(null);
+        self::assertNull($this->siteAccessService->getCurrent());
+
+        // 4. Re-dispatch as received and verify scope change event fires
+        $capturedEvents = [];
+        $this->eventDispatcher->addListener(
+            MVCEvents::CONFIG_SCOPE_CHANGE,
+            static function (ScopeChangeEvent $event) use (&$capturedEvents): void {
+                $capturedEvents[] = $event;
+            },
+        );
+
+        $envelope = Envelope::wrap($envelope, [new ReceivedStamp('test')]);
+        $this->bus->dispatch($envelope);
+
+        self::assertCount(1, $capturedEvents);
+        self::assertSame('__default_site_access__', $capturedEvents[0]->getSiteAccess()->name);
     }
 
     /**

--- a/tests/integration/MessageBusTest.php
+++ b/tests/integration/MessageBusTest.php
@@ -14,17 +14,18 @@ use Ibexa\Contracts\Test\Core\IbexaKernelTestCase;
 use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessage;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessageHandler;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class MessageBusTest extends IbexaKernelTestCase
 {
@@ -34,7 +35,7 @@ final class MessageBusTest extends IbexaKernelTestCase
 
     private FooMessageHandler $fooHandler;
 
-    private SiteAccessServiceInterface $siteAccessService;
+    private SiteAccessService $siteAccessService;
 
     private EventDispatcherInterface $eventDispatcher;
 
@@ -44,8 +45,14 @@ final class MessageBusTest extends IbexaKernelTestCase
         $this->bus = $core->getServiceByClassName(MessageBusInterface::class, 'ibexa.messenger.bus');
         $this->receiver = $core->getServiceByClassName(ReceiverInterface::class, 'ibexa.messenger.transport');
         $this->fooHandler = $core->getServiceByClassName(FooMessageHandler::class);
-        $this->siteAccessService = $core->getServiceByClassName(SiteAccessServiceInterface::class);
-        $this->eventDispatcher = self::getContainer()->get('event_dispatcher');
+
+        $siteAccessService = $core->getServiceByClassName(SiteAccessServiceInterface::class);
+        self::assertInstanceOf(SiteAccessService::class, $siteAccessService);
+        $this->siteAccessService = $siteAccessService;
+
+        $eventDispatcher = self::getContainer()->get('event_dispatcher');
+        self::assertInstanceOf(EventDispatcherInterface::class, $eventDispatcher);
+        $this->eventDispatcher = $eventDispatcher;
 
         // Clear any SiteAccess set by the kernel to prevent the subscriber from stamping
         // envelopes with a SiteAccess name that may not exist in the provider.


### PR DESCRIPTION
| :ticket: Issue | IBX-11682 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
When messages are dispatched to the Ibexa Messenger bus and consumed by a worker, the worker process has **no knowledge of which SiteAccess the message originated from**. This causes handlers to execute without the correct SiteAccess scope, leading to incorrect configuration resolution, wrong content tree roots, and other SiteAccess-dependent behavior.

Introduces a  SiteAccessStamp mechanism that preserves the originating SiteAccess context across the dispatch/consume boundary:

 * `SiteAccessStamp` - a new Messenger stamp that carries the SiteAccess name on the envelope.
 * `SendMessageSiteAccessSubscriber` - listens to `SendMessageToTransportsEvent` and automatically stamps outgoing envelopes with the current SiteAccess name (if one is active). This ensures every message sent to a transport carries SiteAccess context without requiring callers to add the stamp manually.
 * `SiteAccessMiddleware` - a bus middleware that runs on the consume side. When handling an envelope that carries a `SiteAccessStamp`, it resolves the SiteAccess by name and dispatches a `CONFIG_SCOPE_CHANGE` event, restoring the correct configuration scope before the handler executes.
 * The middleware is registered in the `ibexa.messenger.bus` middleware chain, after  `SudoMiddleware`.


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
