### PR TITLE
IBX-11974: UserPermission middleware

### DIFF
--- a/src/bundle/DependencyInjection/IbexaMessengerExtension.php
+++ b/src/bundle/DependencyInjection/IbexaMessengerExtension.php
@@ -10,6 +10,7 @@ namespace Ibexa\Bundle\Messenger\DependencyInjection;
 
 use Ibexa\Bundle\Messenger\Middleware\DeduplicateMiddleware;
 use Ibexa\Bundle\Messenger\Middleware\SudoMiddleware;
+use Ibexa\Bundle\Messenger\Middleware\UserPermissionMiddleware;
 use Ibexa\Bundle\Messenger\Serializer\Normalizer\LockKeyNormalizer;
 use Ibexa\Contracts\Messenger\Transport\MessageProviderInterface;
 use LogicException;
@@ -123,6 +124,7 @@ final class IbexaMessengerExtension extends ConfigurableExtension implements Pre
 
         $middleware = [
             ['id' => SudoMiddleware::class],
+            ['id' => UserPermissionMiddleware::class],
         ];
 
         if ($mergedConfig['deduplication_lock_storage']['enabled'] === true) {

--- a/src/bundle/Middleware/UserPermissionMiddleware.php
+++ b/src/bundle/Middleware/UserPermissionMiddleware.php
@@ -17,12 +17,12 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 
 final class UserPermissionMiddleware implements MiddlewareInterface
 {
-    public function __construct(private PermissionResolver $permissionResolver)
-    {
-    }
+    public function __construct(private PermissionResolver $permissionResolver) {}
 
-    public function handle(Envelope $envelope, StackInterface $stack): Envelope
-    {
+    public function handle(
+        Envelope $envelope,
+        StackInterface $stack
+    ): Envelope {
         $stamp = $envelope->last(UserPermissionStamp::class);
         if ($stamp === null) {
             return $stack->next()->handle($envelope, $stack);

--- a/src/bundle/Middleware/UserPermissionMiddleware.php
+++ b/src/bundle/Middleware/UserPermissionMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Messenger\Middleware;
+
+use Ibexa\Bundle\Messenger\Stamp\UserPermissionStamp;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Core\Repository\Values\User\UserReference;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class UserPermissionMiddleware implements MiddlewareInterface
+{
+    public function __construct(private PermissionResolver $permissionResolver)
+    {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $stamp = $envelope->last(UserPermissionStamp::class);
+        if ($stamp === null) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $previousUserReference = $this->permissionResolver->getCurrentUserReference();
+        $this->permissionResolver->setCurrentUserReference(
+            new UserReference($stamp->userId)
+        );
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            $this->permissionResolver->setCurrentUserReference($previousUserReference);
+        }
+    }
+}

--- a/src/bundle/Middleware/UserPermissionMiddleware.php
+++ b/src/bundle/Middleware/UserPermissionMiddleware.php
@@ -15,7 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
-final class UserPermissionMiddleware implements MiddlewareInterface
+final readonly class UserPermissionMiddleware implements MiddlewareInterface
 {
     public function __construct(private PermissionResolver $permissionResolver) {}
 

--- a/src/bundle/Resources/config/services/buses.yaml
+++ b/src/bundle/Resources/config/services/buses.yaml
@@ -29,6 +29,8 @@ services:
         arguments:
             - '@ibexa.messenger.lock_factory'
 
+    Ibexa\Bundle\Messenger\Middleware\UserPermissionMiddleware: ~
+
     Ibexa\Bundle\Messenger\Transport\Sender\SendersLocator:
         decorates: 'messenger.senders_locator'
         decoration_on_invalid: null

--- a/src/bundle/Stamp/UserPermissionStamp.php
+++ b/src/bundle/Stamp/UserPermissionStamp.php
@@ -12,7 +12,5 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 
 final readonly class UserPermissionStamp implements StampInterface
 {
-    public function __construct(public int $userId)
-    {
-    }
+    public function __construct(public int $userId) {}
 }

--- a/src/bundle/Stamp/UserPermissionStamp.php
+++ b/src/bundle/Stamp/UserPermissionStamp.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final readonly class UserPermissionStamp implements StampInterface
+{
+    public function __construct(public int $userId)
+    {
+    }
+}

--- a/tests/bundle/DependencyInjection/IbexaMessengerExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaMessengerExtensionTest.php
@@ -10,6 +10,8 @@ namespace Ibexa\Tests\Bundle\Messenger\DependencyInjection;
 
 use Ibexa\Bundle\Messenger\DependencyInjection\IbexaMessengerExtension;
 use Ibexa\Bundle\Messenger\Middleware\DeduplicateMiddleware;
+use Ibexa\Bundle\Messenger\Middleware\SudoMiddleware;
+use Ibexa\Bundle\Messenger\Middleware\UserPermissionMiddleware;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
 final class IbexaMessengerExtensionTest extends AbstractExtensionTestCase
@@ -33,6 +35,8 @@ final class IbexaMessengerExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
+        self::assertTrue($this->container->hasDefinition(SudoMiddleware::class));
+        self::assertTrue($this->container->hasDefinition(UserPermissionMiddleware::class));
         self::assertTrue($this->container->hasDefinition(DeduplicateMiddleware::class));
         self::assertTrue($this->container->hasDefinition('ibexa.messenger.lock_factory'));
         self::assertTrue($this->container->hasDefinition('ibexa.messenger.lock_store.dbal'));
@@ -46,6 +50,8 @@ final class IbexaMessengerExtensionTest extends AbstractExtensionTestCase
             ],
         ]);
 
+        self::assertTrue($this->container->hasDefinition(SudoMiddleware::class));
+        self::assertTrue($this->container->hasDefinition(UserPermissionMiddleware::class));
         self::assertFalse($this->container->hasDefinition(DeduplicateMiddleware::class));
         self::assertFalse($this->container->hasDefinition('ibexa.messenger.lock_factory'));
         self::assertFalse($this->container->hasDefinition('ibexa.messenger.lock_store.dbal'));

--- a/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
+++ b/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
@@ -13,7 +13,9 @@ use Ibexa\Bundle\Messenger\Stamp\UserPermissionStamp;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
 use Ibexa\Core\Repository\Values\User\UserReference;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
@@ -26,22 +28,20 @@ final class UserPermissionMiddlewareTest extends TestCase
     private const PREVIOUS_USER_ID = 14;
     private const STAMP_USER_ID = 42;
 
-    private MockObject&PermissionResolver $permissionResolver;
+    private Stub & PermissionResolver $permissionResolver;
 
-    private MockObject&StackInterface $stack;
+    private MockObject & StackInterface $stack;
 
     private UserPermissionMiddleware $middleware;
 
     protected function setUp(): void
     {
-        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->permissionResolver = self::createStub(PermissionResolver::class);
         $this->stack = $this->createMock(StackInterface::class);
         $this->middleware = new UserPermissionMiddleware($this->permissionResolver);
     }
 
-    /**
-     * @dataProvider provideForTestHandle
-     */
+    #[DataProvider('provideForTestHandle')]
     public function testHandle(
         ?UserPermissionStamp $stamp,
         int $expectedUserIdInNext,

--- a/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
+++ b/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
@@ -15,7 +15,6 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReferenc
 use Ibexa\Core\Repository\Values\User\UserReference;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
@@ -28,7 +27,7 @@ final class UserPermissionMiddlewareTest extends TestCase
     private const PREVIOUS_USER_ID = 14;
     private const STAMP_USER_ID = 42;
 
-    private Stub & PermissionResolver $permissionResolver;
+    private MockObject & PermissionResolver $permissionResolver;
 
     private MockObject & StackInterface $stack;
 
@@ -36,7 +35,7 @@ final class UserPermissionMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->permissionResolver = self::createStub(PermissionResolver::class);
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
         $this->stack = $this->createMock(StackInterface::class);
         $this->middleware = new UserPermissionMiddleware($this->permissionResolver);
     }
@@ -51,12 +50,18 @@ final class UserPermissionMiddlewareTest extends TestCase
         $previousUserReference = new UserReference(self::PREVIOUS_USER_ID);
         $currentUserReference = $previousUserReference;
 
+        // With a stamp the middleware reads the current reference once and the next middleware
+        // reads it again; without a stamp only the next middleware reads it.
         $this->permissionResolver
+            ->expects(null !== $stamp ? self::exactly(2) : self::once())
             ->method('getCurrentUserReference')
             ->willReturnCallback(static function () use (&$currentUserReference): APIUserReference {
                 return $currentUserReference;
             });
+        // With a stamp the reference is set to the stamp user and then restored in the finally block;
+        // without a stamp it is never touched.
         $this->permissionResolver
+            ->expects(null !== $stamp ? self::exactly(2) : self::never())
             ->method('setCurrentUserReference')
             ->willReturnCallback(static function (APIUserReference $reference) use (&$currentUserReference): void {
                 $currentUserReference = $reference;

--- a/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
+++ b/tests/bundle/Middleware/UserPermissionMiddlewareTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Messenger\Middleware;
+
+use Ibexa\Bundle\Messenger\Middleware\UserPermissionMiddleware;
+use Ibexa\Bundle\Messenger\Stamp\UserPermissionStamp;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
+use Ibexa\Core\Repository\Values\User\UserReference;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Throwable;
+
+final class UserPermissionMiddlewareTest extends TestCase
+{
+    private const PREVIOUS_USER_ID = 14;
+    private const STAMP_USER_ID = 42;
+
+    private MockObject&PermissionResolver $permissionResolver;
+
+    private MockObject&StackInterface $stack;
+
+    private UserPermissionMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->stack = $this->createMock(StackInterface::class);
+        $this->middleware = new UserPermissionMiddleware($this->permissionResolver);
+    }
+
+    /**
+     * @dataProvider provideForTestHandle
+     */
+    public function testHandle(
+        ?UserPermissionStamp $stamp,
+        int $expectedUserIdInNext,
+        ?Throwable $exception
+    ): void {
+        // A stateful resolver: getCurrentUserReference() reflects the latest setCurrentUserReference().
+        $previousUserReference = new UserReference(self::PREVIOUS_USER_ID);
+        $currentUserReference = $previousUserReference;
+
+        $this->permissionResolver
+            ->method('getCurrentUserReference')
+            ->willReturnCallback(static function () use (&$currentUserReference): APIUserReference {
+                return $currentUserReference;
+            });
+        $this->permissionResolver
+            ->method('setCurrentUserReference')
+            ->willReturnCallback(static function (APIUserReference $reference) use (&$currentUserReference): void {
+                $currentUserReference = $reference;
+            });
+
+        // Capture the user id visible to the next middleware at invocation time.
+        $userIdSeenByNext = null;
+        $nextMiddleware = $this->createMock(MiddlewareInterface::class);
+        $nextMiddleware
+            ->expects(self::once())
+            ->method('handle')
+            ->willReturnCallback(function (Envelope $envelope) use (&$userIdSeenByNext, $exception): Envelope {
+                $userIdSeenByNext = $this->permissionResolver->getCurrentUserReference()->getUserId();
+                if ($exception !== null) {
+                    throw $exception;
+                }
+
+                return $envelope;
+            });
+
+        $this->stack
+            ->expects(self::once())
+            ->method('next')
+            ->willReturn($nextMiddleware);
+
+        $envelope = new Envelope(new \stdClass(), $stamp !== null ? [$stamp] : []);
+
+        try {
+            $this->middleware->handle($envelope, $this->stack);
+            self::assertNull($exception, 'Expected the next middleware exception to propagate.');
+        } catch (Throwable $caught) {
+            self::assertSame($exception, $caught);
+        }
+
+        self::assertSame(
+            $expectedUserIdInNext,
+            $userIdSeenByNext,
+            'Next middleware was called with an unexpected current user reference.'
+        );
+        self::assertSame(
+            $previousUserReference,
+            $currentUserReference,
+            'The previous user reference was not restored after handling.'
+        );
+    }
+
+    /**
+     * @return iterable<string, array{UserPermissionStamp|null, int, Throwable|null}>
+     */
+    public static function provideForTestHandle(): iterable
+    {
+        yield 'no stamp, next succeeds' => [
+            null,
+            self::PREVIOUS_USER_ID,
+            null,
+        ];
+
+        yield 'no stamp, next throws' => [
+            null,
+            self::PREVIOUS_USER_ID,
+            new RuntimeException('Next middleware failed'),
+        ];
+
+        yield 'with stamp, next succeeds' => [
+            new UserPermissionStamp(self::STAMP_USER_ID),
+            self::STAMP_USER_ID,
+            null,
+        ];
+
+        yield 'with stamp, next throws' => [
+            new UserPermissionStamp(self::STAMP_USER_ID),
+            self::STAMP_USER_ID,
+            new RuntimeException('Next middleware failed'),
+        ];
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | [IBX-11974](https://ibexa.atlassian.net/browse/IBX-11974) |
|----------------|-----------|

#### Related PRs: 
- depends on: https://github.com/ibexa/messenger/pull/16

#### Description:
Adds a Symfony Messenger middleware that preserves the dispatching user's permission context across async handling. A new `UserPermissionStamp` carries the user ID on the envelope; `UserPermissionMiddleware` reads it, sets the current user on the `PermissionResolver` for the duration of handling, and restores the previous user reference afterwards (via `try/finally`, so it's reverted even when a downstream handler throws). When no stamp is present, the middleware is a no-op and leaves the permission context untouched. The middleware is registered in the bus configuration (`buses.yaml` / `IbexaMessengerExtension`) by default.

Covered by a data-provider unit test exercising all four branches (stamp present/absent × handler succeeds/throws), plus extension-test assertions confirming the middleware is wired into the container.

#### For QA:

#### Documentation:
I guess we could describe the middleware in https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/background_tasks/ (if we're documenting on each middleware level too)

[IBX-11974]: https://ibexa.atlassian.net/browse/IBX-11974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ