### PR TITLE
IBX-11974: Added deprecation for automatically attached SudoStamp in SudoMiddleware

### DIFF
--- a/src/bundle/Middleware/SudoMiddleware.php
+++ b/src/bundle/Middleware/SudoMiddleware.php
@@ -30,6 +30,13 @@ final class SudoMiddleware implements MiddlewareInterface
     ): Envelope {
         $stamp = $envelope->last(SudoStamp::class);
         if ($stamp === null) {
+            trigger_deprecation(
+                'ibexa/messenger',
+                '5.0.9',
+                'Since 6.0.0, %s will not be attached automatically to all messages. You will need to add the stamp explicitly when dispatching the message.',
+                SudoStamp::class,
+            );
+
             $envelope = $envelope->with(new SudoStamp());
 
             $envelope = $this->repository->sudo(


### PR DESCRIPTION
| :ticket: Issue | [IBX-11974](https://ibexa.atlassian.net/browse/IBX-11974) |
|----------------|-----------|

#### Related PRs: 
- depends on: https://github.com/ibexa/messenger/pull/16

#### Description:
Added deprecation for automatically attached SudoStamp in SudoMiddleware - since 6.0.0 we need to add that stamp explicitly in every dispatched message if we expect to skip user permission checking for async processing.

#### For QA:
No behaviour changed - that will happen in 6.0.x version.

#### Documentation:
I guess we need to document that if we're tracking all deprecations in docs

[IBX-11974]: https://ibexa.atlassian.net/browse/IBX-11974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ