### PR TITLE
IBX-11974: Moved DeduplicateStamp to contracts and deprecated bundle class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,7 +55,7 @@ parameters:
 			path: src/bundle/Serializer/Normalizer/DeduplicateStampNormalizer.php
 
 		-
-			message: '#^Return type \(Ibexa\\Bundle\\Messenger\\Stamp\\DeduplicateStamp\) of method Ibexa\\Bundle\\Messenger\\Serializer\\Normalizer\\DeduplicateStampNormalizer\:\:denormalize\(\) should be covariant with return type \(\(\$type is class\-string\<object\> \? object \: mixed\)\) of method Symfony\\Component\\Serializer\\Normalizer\\DenormalizerInterface\:\:denormalize\(\)$#'
+			message: '#^Return type \(Ibexa\\Contracts\\Messenger\\Stamp\\DeduplicateStamp\) of method Ibexa\\Bundle\\Messenger\\Serializer\\Normalizer\\DeduplicateStampNormalizer\:\:denormalize\(\) should be covariant with return type \(\(\$type is class\-string\<object\> \? object \: mixed\)\) of method Symfony\\Component\\Serializer\\Normalizer\\DenormalizerInterface\:\:denormalize\(\)$#'
 			identifier: method.childReturnType
 			count: 1
 			path: src/bundle/Serializer/Normalizer/DeduplicateStampNormalizer.php

--- a/src/bundle/Middleware/DeduplicateMiddleware.php
+++ b/src/bundle/Middleware/DeduplicateMiddleware.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Messenger\Middleware;
 
-use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;

--- a/src/bundle/Serializer/Normalizer/DeduplicateStampNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/DeduplicateStampNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\Messenger\Serializer\Normalizer;
 
 use Closure;
-use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
 use ReflectionClass;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;

--- a/src/bundle/Stamp/DeduplicateStamp.php
+++ b/src/bundle/Stamp/DeduplicateStamp.php
@@ -8,52 +8,26 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Messenger\Stamp;
 
-use Symfony\Component\Lock\Key;
-use Symfony\Component\Messenger\Exception\LogicException;
-use Symfony\Component\Messenger\Stamp\StampInterface;
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp as ContractsDeduplicateStamp;
 
 /**
- * (c) Fabien Potencier <fabien@symfony.com>.
- *
- * Original code: https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+ * @deprecated since Ibexa 5.0.9, use {@see ContractsDeduplicateStamp} instead.
  */
-final class DeduplicateStamp implements StampInterface
+class DeduplicateStamp extends ContractsDeduplicateStamp
 {
-    private Key $key;
-
-    private ?float $ttl;
-
-    private bool $onlyDeduplicateInQueue;
-
     public function __construct(
         string $key,
         ?float $ttl = 300.0,
         bool $onlyDeduplicateInQueue = false
     ) {
-        if (!class_exists(Key::class)) {
-            throw new LogicException(sprintf(
-                'You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".',
-                self::class,
-            ));
-        }
+        trigger_deprecation(
+            'ibexa/messenger',
+            '5.0.9',
+            'The "%s" class is deprecated, use "%s" instead.',
+            self::class,
+            ContractsDeduplicateStamp::class,
+        );
 
-        $this->key = new Key($key);
-        $this->ttl = $ttl;
-        $this->onlyDeduplicateInQueue = $onlyDeduplicateInQueue;
-    }
-
-    public function onlyDeduplicateInQueue(): bool
-    {
-        return $this->onlyDeduplicateInQueue;
-    }
-
-    public function getKey(): Key
-    {
-        return $this->key;
-    }
-
-    public function getTtl(): ?float
-    {
-        return $this->ttl;
+        parent::__construct($key, $ttl, $onlyDeduplicateInQueue);
     }
 }

--- a/src/contracts/Stamp/DeduplicateStamp.php
+++ b/src/contracts/Stamp/DeduplicateStamp.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Messenger\Stamp;
+
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * (c) Fabien Potencier <fabien@symfony.com>.
+ *
+ * Original code: https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+ */
+class DeduplicateStamp implements StampInterface
+{
+    private Key $key;
+
+    private ?float $ttl;
+
+    private bool $onlyDeduplicateInQueue;
+
+    public function __construct(
+        string $key,
+        ?float $ttl = 300.0,
+        bool $onlyDeduplicateInQueue = false
+    ) {
+        if (!class_exists(Key::class)) {
+            throw new LogicException(sprintf(
+                'You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".',
+                self::class,
+            ));
+        }
+
+        $this->key = new Key($key);
+        $this->ttl = $ttl;
+        $this->onlyDeduplicateInQueue = $onlyDeduplicateInQueue;
+    }
+
+    public function onlyDeduplicateInQueue(): bool
+    {
+        return $this->onlyDeduplicateInQueue;
+    }
+
+    public function getKey(): Key
+    {
+        return $this->key;
+    }
+
+    public function getTtl(): ?float
+    {
+        return $this->ttl;
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/DeduplicateStampNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/DeduplicateStampNormalizerTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Bundle\Messenger\Serializer\Normalizer;
 
 use Ibexa\Bundle\Messenger\Serializer\Normalizer\DeduplicateStampNormalizer;
-use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/integration/MessageBusTest.php
+++ b/tests/integration/MessageBusTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Integration\Messenger;
 
-use Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp;
+use Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp;
 use Ibexa\Contracts\Test\Core\IbexaKernelTestCase;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessage;
 use Ibexa\Tests\Integration\Messenger\Stubs\FooMessageHandler;


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

#### Description

Moves `DeduplicateStamp` to the contracts namespace and deprecates the original bundle class, following the same pattern used previously for `SudoStamp` and `UserPermissionStamp` (#19).

- `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` is now the canonical class. Its `final` keyword was removed so the deprecated class can extend it. In 6.0 I'll revert it as final.
- `Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp` is kept as a backward-compatible shim that extends the contracts class and is marked `@deprecated` (triggers a deprecation on instantiation).
- All internal references (middleware, normalizer, tests) now point at the contracts class.
- Updated the PHPStan baseline entry to reflect the normalizer's new return type FQCN.
