### PR TITLE
IBX-12084: Added deprecation to DeduplicateStamp in contracts

### DIFF
--- a/src/contracts/Stamp/DeduplicateStamp.php
+++ b/src/contracts/Stamp/DeduplicateStamp.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
  *
  * Original code: https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
  *
- * @deprecated since Ibexa 5.0.9. Starting from Ibexa 6.0, the native {@see SymfonyDeduplicateStamp}
+ * @deprecated since Ibexa 5.0.10. Starting from Ibexa 6.0, the native {@see SymfonyDeduplicateStamp}
  * will be used instead. Ibexa 5.0 is not prepared to handle the Symfony stamp yet, so keep using
  * this class until you upgrade.
  */
@@ -37,7 +37,7 @@ class DeduplicateStamp implements StampInterface
     ) {
         trigger_deprecation(
             'ibexa/messenger',
-            '5.0.9',
+            '5.0.10',
             'The "%s" class is deprecated, starting from Ibexa 6.0 the native "%s" will be used instead.',
             self::class,
             SymfonyDeduplicateStamp::class,

--- a/src/contracts/Stamp/DeduplicateStamp.php
+++ b/src/contracts/Stamp/DeduplicateStamp.php
@@ -10,12 +10,17 @@ namespace Ibexa\Contracts\Messenger\Stamp;
 
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp as SymfonyDeduplicateStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
  * (c) Fabien Potencier <fabien@symfony.com>.
  *
  * Original code: https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+ *
+ * @deprecated since Ibexa 5.0.9. Starting from Ibexa 6.0, the native {@see SymfonyDeduplicateStamp}
+ * will be used instead. Ibexa 5.0 is not prepared to handle the Symfony stamp yet, so keep using
+ * this class until you upgrade.
  */
 class DeduplicateStamp implements StampInterface
 {
@@ -30,6 +35,14 @@ class DeduplicateStamp implements StampInterface
         ?float $ttl = 300.0,
         bool $onlyDeduplicateInQueue = false
     ) {
+        trigger_deprecation(
+            'ibexa/messenger',
+            '5.0.9',
+            'The "%s" class is deprecated, starting from Ibexa 6.0 the native "%s" will be used instead.',
+            self::class,
+            SymfonyDeduplicateStamp::class,
+        );
+
         if (!class_exists(Key::class)) {
             throw new LogicException(sprintf(
                 'You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".',


### PR DESCRIPTION
| :ticket: Issue | [IBX-12084](https://ibexa.atlassian.net/browse/IBX-12084) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Deprecated `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` in the same way as the already-deprecated `Ibexa\Bundle\Messenger\Stamp\DeduplicateStamp`: a `@deprecated` docblock annotation plus a `trigger_deprecation()` call in the constructor.

The class is a backport of Symfony's `DeduplicateStamp`. Starting from Ibexa 6.0 the native `Symfony\Component\Messenger\Stamp\DeduplicateStamp` will be used instead, but Ibexa 5.0 is not prepared to handle the Symfony stamp yet, so on 5.0 this class remains the one to use until upgrade.

#### For QA:
No behaviour change — this only adds a deprecation notice. Constructing `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` now emits a `ibexa/messenger` deprecation; message deduplication itself works as before.

#### Documentation:
Upgrade notes: `Ibexa\Contracts\Messenger\Stamp\DeduplicateStamp` is deprecated since Ibexa 5.0.9. Starting from Ibexa 6.0, the native `Symfony\Component\Messenger\Stamp\DeduplicateStamp` will be used instead; keep using the contracts class on 5.0.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
-->


[IBX-12084]: https://ibexa.atlassian.net/browse/IBX-12084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ